### PR TITLE
顯示輪廓時如果物體高度有小數點會卡死

### DIFF
--- a/fluxghost/api/control.py
+++ b/fluxghost/api/control.py
@@ -733,7 +733,7 @@ def control_api_mixin(cls):
                 self.raw_sock.sock.send(message.encode() + b"\n")
 
         def laser_show_outline(self, object_height, *positions):
-            object_height = int(object_height) + 10
+            object_height = float(object_height) + 10
 
             def trace_to_command(trace):
                 fp = trace.pop(0)


### PR DESCRIPTION
use float() instead int()