### PR TITLE
Add detect_blobs and image_contour opencv commands

### DIFF
--- a/docs/api/opencv.md
+++ b/docs/api/opencv.md
@@ -2,7 +2,7 @@
 
 `ws://127.0.0.1:8000/ws/opencv`
 
-Image sharpening service. The client uploads an image once (keyed by its URL), then can request unsharp-mask sharpening of that cached image; the sharpened result is returned as a PNG binary frame.
+General OpenCV image service. The client uploads an image once (keyed by its URL), then can request unsharp-mask sharpening of that cached image; the sharpened result is returned as a PNG binary frame. It also provides one-shot circular-blob detection (`detect_blobs`) used by Beam Studio's Print and Cut alignment.
 
 - **Handler**: `fluxghost/api/opencv.py` (`opencv_mixin`), wrapper `fluxghost/websocket/opencv.py`, route `fluxghost/http_websocket_route.py:29` - **Beam Studio client**: `packages/core/src/web/helpers/api/open-cv.ts` (`OpenCVWebSocket`, used by the Sharpen dialog `app/components/dialogs/image/Sharpen.tsx`)
 
@@ -42,6 +42,42 @@ If `img_url` has not been uploaded on this connection:
 ```
 
 The Beam Studio client reacts to `need_upload` by fetching the URL, running `upload`, and re-sending the same `sharpen` command (`open-cv.ts:82-112`).
+
+### `detect_blobs <file_length> [<json_params>]`
+
+Detects dark circular blobs (e.g. printed alignment marks) with `cv2.SimpleBlobDetector` (`find_blob_centers` in `fluxghost/utils/camera/corner_detection/find_corners.py`). Unlike `sharpen`, this is a one-shot command: the image is streamed directly after the command and is not cached in `self.imgs`.
+
+`json_params` is an optional JSON object; recognized keys are forwarded to `find_blob_centers`: `min_threshold`, `max_threshold`, `min_area`, `max_area`, `min_circularity`, `max_circularity`, `min_convexity`, `max_convexity`. Unknown keys are ignored. The uploaded image is decoded with PIL, converted to RGB then BGR, so any common format (PNG/JPEG, with or without alpha) works.
+
+Response `points` are blob centers in image pixel coordinates.
+
+```
+→ detect_blobs 152833 {"min_area": 500, "max_area": 3000, "min_circularity": 0.7}
+← {"status": "continue"}
+→ <binary chunks totalling 152833 bytes>
+← {"status": "ok", "points": [[102.5, 88.1], [1893.2, 87.4], [103.0, 1401.8], [1894.1, 1400.2]]}
+```
+
+- **Beam Studio client**: `OpenCVWebSocket.detectBlobs` (`packages/core/src/web/helpers/api/open-cv.ts`), used by `app/components/dialogs/PrintAndCut/utils/alignByCamera.ts`.
+
+### `image_contour <file_length> [<json_params>]`
+
+Detects the outer silhouette of the image content and returns its contours — used by Beam Studio's Print and Cut, which builds the offset cut path client-side (round-join ClipperOffset on the raw silhouette). One-shot command like `detect_blobs`.
+
+The mask comes from the alpha channel when the image has transparency (`alpha > alpha_threshold`, default 0 so anti-aliased thin strokes are kept), otherwise from luminance (`gray < threshold`, i.e. dark content on a light background), then `cv2.findContours(RETR_EXTERNAL)` + `approxPolyDP(epsilon)`. Contours smaller than `min_area` (px²) are dropped.
+
+`json_params` keys (all optional): `threshold` (int, default 250), `epsilon` (float, default 1.0), `min_area` (float, default 100), `alpha_threshold` (int, default 0).
+
+Response `contours` is a list of contours, each a list of `[x, y]` points in image pixel coordinates.
+
+```
+→ image_contour 152833 {"threshold": 250, "epsilon": 1.0}
+← {"status": "continue"}
+→ <binary chunks totalling 152833 bytes>
+← {"status": "ok", "contours": [[[18.0, 42.0], [305.0, 12.0], ...]]}
+```
+
+- **Beam Studio client**: `OpenCVWebSocket.imageContour` (`packages/core/src/web/helpers/api/open-cv.ts`), used by `app/components/dialogs/PrintAndCut/utils/computeCutPathD.ts` (caches the contours per design, offsets them with ClipperOffset, and falls back to a bounding-box outline when this call fails).
 
 ## Errors
 

--- a/fluxghost/api/opencv.py
+++ b/fluxghost/api/opencv.py
@@ -1,11 +1,14 @@
 import collections
 import contextlib
 import io
+import json
 import logging
 
 import cv2
 import numpy as np
 from PIL import Image
+
+from fluxghost.utils.camera.corner_detection.find_corners import find_blob_centers
 
 from .misc import BinaryHelperMixin, BinaryUploadHelper, OnTextMessageMixin
 
@@ -19,6 +22,8 @@ def opencv_mixin(cls):
             self.cmd_mapping = {
                 'upload': [self.cmd_upload_image],
                 'sharpen': [self.cmd_sharpen],
+                'detect_blobs': [self.cmd_detect_blobs],
+                'image_contour': [self.cmd_image_contour],
             }
             self.imgs = {}
             self.imgs_history = collections.deque([])
@@ -42,6 +47,80 @@ def opencv_mixin(cls):
                 self.imgs[img_url] = open_cv_img
                 self.update_history(img_url)
                 self.send_ok()
+
+            helper = BinaryUploadHelper(int(file_length), upload_callback)
+            self.set_binary_helper(helper)
+            self.send_json(status='continue')
+
+        def cmd_detect_blobs(self, params):
+            # detect_blobs <file_length> [<json_params>]
+            # json_params: optional kwargs for find_blob_centers,
+            # e.g. {"min_area": 100, "max_area": 1000, "min_circularity": 0.7}
+            params = params.split(' ', 1)
+            file_length = int(params[0])
+            options = json.loads(params[1]) if len(params) > 1 and params[1].strip() else {}
+            allowed_keys = (
+                'min_threshold',
+                'max_threshold',
+                'min_area',
+                'max_area',
+                'min_circularity',
+                'max_circularity',
+                'min_convexity',
+                'max_convexity',
+            )
+            kwargs = {key: options[key] for key in allowed_keys if key in options}
+
+            def upload_callback(buf):
+                img = Image.open(io.BytesIO(buf)).convert('RGB')
+                open_cv_img = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+                logger.info('Detecting blobs with params: {}'.format(kwargs))
+                centers = find_blob_centers(open_cv_img, **kwargs)
+                logger.info('Detected {} blobs'.format(len(centers)))
+                self.send_ok(points=[[float(x), float(y)] for x, y in centers])
+
+            helper = BinaryUploadHelper(int(file_length), upload_callback)
+            self.set_binary_helper(helper)
+            self.send_json(status='continue')
+
+        def cmd_image_contour(self, params):
+            # image_contour <file_length> [<json_params>]
+            # json_params: {"threshold": 250, "epsilon": 1.0, "min_area": 100, "alpha_threshold": 0}
+            # Detects the outer silhouette of the image content (alpha channel when
+            # present, otherwise dark-on-light with luminance < threshold) and returns
+            # the outer contours in image pixel coordinates. Offsetting/smoothing the
+            # outline is done client-side (Beam Studio runs a ClipperOffset on it).
+            params = params.split(' ', 1)
+            file_length = int(params[0])
+            options = json.loads(params[1]) if len(params) > 1 and params[1].strip() else {}
+            threshold = int(options.get('threshold', 250))
+            epsilon = float(options.get('epsilon', 1.0))
+            min_area = float(options.get('min_area', 100))
+            # any non-zero coverage counts: thin strokes anti-alias to low alpha
+            # and would vanish from the mask with a mid-range threshold
+            alpha_threshold = int(options.get('alpha_threshold', 0))
+
+            def upload_callback(buf):
+                img = Image.open(io.BytesIO(buf)).convert('RGBA')
+                arr = np.array(img)
+                alpha = arr[:, :, 3]
+                if (alpha < 255).any():
+                    mask = (alpha > alpha_threshold).astype(np.uint8) * 255
+                else:
+                    gray = cv2.cvtColor(arr, cv2.COLOR_RGBA2GRAY)
+                    mask = (gray < threshold).astype(np.uint8) * 255
+                # pad so content touching the image border still closes its contour
+                pad = 1
+                mask = cv2.copyMakeBorder(mask, pad, pad, pad, pad, cv2.BORDER_CONSTANT, value=0)
+                contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                result = []
+                for contour in contours:
+                    if cv2.contourArea(contour) < min_area:
+                        continue
+                    approx = cv2.approxPolyDP(contour, epsilon, True)
+                    result.append([[float(point[0][0] - pad), float(point[0][1] - pad)] for point in approx])
+                logger.info('Detected {} contours'.format(len(result)))
+                self.send_ok(contours=result)
 
             helper = BinaryUploadHelper(int(file_length), upload_callback)
             self.set_binary_helper(helper)


### PR DESCRIPTION
## Summary

Two new one-shot commands on the `/ws/opencv` endpoint, both consumed by Beam Studio's Print and Cut flow (beam-studio `feat/print-and-cut`):

- **`detect_blobs <file_length> [<json_params>]`** — detects dark circular blobs (the printed alignment marks) via `find_blob_centers` / `cv2.SimpleBlobDetector`. Optional JSON params are whitelisted and forwarded (`min_area`, `max_area`, `min_circularity`, …). Returns blob centers in image px.
- **`image_contour <file_length> [<json_params>]`** — traces the outer silhouette of the uploaded image: alpha-channel mask when the image has transparency (threshold 0 so anti-aliased thin strokes survive), luminance mask otherwise; `RETR_EXTERNAL` + `approxPolyDP`, border-padded so content touching the image edge still closes. Returns contours in image px; the offset cut path is built client-side (ClipperOffset).

Unlike `sharpen`, both stream the image directly after the command instead of using the URL-keyed upload cache.

`docs/api/opencv.md` updated with wire formats, parameters and client references.

## Test plan

- `uv run python tools/ws_smoke.py` → 8 passed, 0 failed, ALL PASS
- Hardware-tested end to end through Beam Studio's Print and Cut dialog (mark detection during the smart camera sweep + contour-based cut path generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)